### PR TITLE
feat: allow user to store location

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -11,6 +11,8 @@ pub struct ConditionsArgs {
 pub enum Command {
     /// Get the current weather conditions
     Current,
+    /// Location, stored or inferred
+    Location(LocationCommand),
     /// weatherapi.com token
     Token(TokenCommand),
 }
@@ -33,4 +35,24 @@ pub enum TokenSubcommand {
 pub struct SetToken {
     /// Your weatherapi.com token
     pub token: String,
+}
+
+#[derive(Debug, Args)]
+pub struct LocationCommand {
+    #[clap(subcommand)]
+    pub command: LocationSubcommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum LocationSubcommand {
+    /// Store your location
+    Set(SetLocation),
+    /// View stored location
+    View,
+}
+
+#[derive(Debug, Args)]
+pub struct SetLocation {
+    /// Location to retrieve weather for ("lat,long" or "city,state")
+    pub location: String,
 }

--- a/src/conditions.rs
+++ b/src/conditions.rs
@@ -2,8 +2,6 @@ use std::convert::From;
 
 use serde::{Deserialize, Serialize};
 
-use crate::location;
-
 static WEATHERAPI_URL: &str = "http://api.weatherapi.com/v1/current.json";
 
 /// PrasedConditions represented as JSON response
@@ -58,12 +56,8 @@ impl Conditions {
     }
 }
 
-pub fn current(
-    key: &str,
-    location: &location::Coordinates,
-) -> Result<Conditions, String> {
-    let q = location.to_string();
-    let query = vec![("key", key), ("q", &q)];
+pub fn current(key: &str, location: &str) -> Result<Conditions, String> {
+    let query = vec![("key", key), ("q", location)];
 
     match ureq::get(WEATHERAPI_URL)
         .query_pairs(query)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,40 +14,41 @@ const CONFIG_NAME: &str = "config";
 #[derive(Deserialize, Serialize, Debug, Default)]
 struct Config {
     weatherapi_token: String,
+    location: String,
 }
 
 pub fn run() {
     let args = ConditionsArgs::parse();
 
     match &args.command {
+        Command::Current => current_conditions(),
+        Command::Location(cmd) => match &cmd.command {
+            LocationSubcommand::Set(location) => {
+                set_location(&location.location);
+            }
+            LocationSubcommand::View => view_location(),
+        },
         Command::Token(cmd) => match &cmd.command {
             TokenSubcommand::Set(token) => set_weatherapi_token(&token.token),
             TokenSubcommand::View => view_weatherapi_token(),
         },
-        Command::Current => current_conditions(),
     }
 }
 
-fn set_weatherapi_token(token: &str) {
-    let config = Config {
-        weatherapi_token: token.to_owned(),
-    };
-
-    confy::store(APP_NAME, CONFIG_NAME, config).unwrap();
-
-    print!("weatherapi.com token stored successfully");
-}
-
-fn view_weatherapi_token() {
-    let config: Config = confy::load(APP_NAME, CONFIG_NAME).unwrap();
-
-    println!("{}", config.weatherapi_token);
+fn load_config() -> Config {
+    confy::load(APP_NAME, CONFIG_NAME).unwrap()
 }
 
 fn current_conditions() {
-    let config: Config = confy::load(APP_NAME, CONFIG_NAME).unwrap();
+    let config = load_config();
+
+    let location = if config.location.is_empty() {
+        location::current().unwrap().to_string()
+    } else {
+        config.location
+    };
+
     let weatherapi_token = config.weatherapi_token;
-    let location = location::current().unwrap();
 
     let mut conditions =
         conditions::current(&weatherapi_token, &location).unwrap();
@@ -60,4 +61,36 @@ fn current_conditions() {
     conditions.set_icon(icons::icon_for(time_of_day, conditions.code));
 
     println!("{}", ureq::serde_json::to_string(&conditions).unwrap());
+}
+
+fn set_location(location: &str) {
+    let mut config = load_config();
+
+    config.location = location.to_owned();
+
+    confy::store(APP_NAME, CONFIG_NAME, config).unwrap();
+
+    print!("location stored successfully");
+}
+
+fn view_location() {
+    let config = load_config();
+
+    println!("{}", config.location);
+}
+
+fn set_weatherapi_token(token: &str) {
+    let mut config = load_config();
+
+    config.weatherapi_token = token.to_owned();
+
+    confy::store(APP_NAME, CONFIG_NAME, config).unwrap();
+
+    print!("weatherapi.com token stored successfully");
+}
+
+fn view_weatherapi_token() {
+    let config: Config = confy::load(APP_NAME, CONFIG_NAME).unwrap();
+
+    println!("{}", config.weatherapi_token);
 }

--- a/src/location.rs
+++ b/src/location.rs
@@ -1,15 +1,15 @@
 use std::fmt;
-use std::num::ParseFloatError;
 use std::str::FromStr;
+use std::string::ParseError;
 
 #[derive(Debug, Default, PartialEq)]
 pub struct Coordinates {
-    latitude: f64,
-    longitude: f64,
+    latitude: String,
+    longitude: String,
 }
 
 impl Coordinates {
-    fn new(lat: f64, long: f64) -> Self {
+    fn new(lat: String, long: String) -> Self {
         Self {
             latitude: lat,
             longitude: long,
@@ -18,7 +18,7 @@ impl Coordinates {
 }
 
 impl FromStr for Coordinates {
-    type Err = ParseFloatError;
+    type Err = ParseError;
 
     fn from_str(text: &str) -> Result<Self, Self::Err> {
         let parts: Vec<&str> = text.split(',').collect();
@@ -28,10 +28,10 @@ impl FromStr for Coordinates {
             // Err(Self::Err)?;
         }
 
-        let lat: f64 = parts[0].parse::<f64>()?;
-        let long: f64 = parts[1].trim().parse::<f64>()?;
+        let lat = parts[0].trim();
+        let long = parts[1].trim();
 
-        Ok(Self::new(lat, long))
+        Ok(Self::new(lat.to_owned(), long.to_owned()))
     }
 }
 
@@ -41,14 +41,12 @@ impl fmt::Display for Coordinates {
     }
 }
 
-pub fn current() -> Result<Coordinates, ParseFloatError> {
-    Ok(Coordinates::new(34.9249, -81.0251))
+pub fn current() -> Result<Coordinates, ParseError> {
+    let response = ureq::get("https://ipinfo.io/loc")
+        .call()
+        .unwrap()
+        .into_string()
+        .unwrap();
 
-    // let response = ureq::get("https://ipinfo.io/loc")
-    //     .call()
-    //     .unwrap()
-    //     .into_string()
-    //     .unwrap();
-
-    // Coordinates::from_str(&response)
+    Coordinates::from_str(&response)
 }


### PR DESCRIPTION
User can now store a their location:

```
conditions location set "New York,NY"
```

The stored location will be used to fetch weather conditions for. If not set then the location will be inferred via ip.

The benefit of storing location is skipping the extra request for location by ip on every call to `current`.

Resolves #13
