### PR TITLE
feat: error reports with `eyre`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,6 +150,7 @@ dependencies = [
  "clap",
  "confy",
  "env_logger",
+ "eyre",
  "lazy_static",
  "log",
  "serde",
@@ -233,6 +234,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "eyre"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,6 +300,12 @@ dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
+
+[[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "io-lifetimes"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ description = "Fetch basic weather conditions for current location"
 clap = { version = "4.3.19", features = ["derive"] }
 confy = "0.5.1"
 env_logger = "0.10.0"
+eyre = "0.6.8"
 lazy_static = "1.4.0"
 log = "0.4.19"
 serde = { version = "1", features = ["derive"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use eyre::WrapErr;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -25,29 +26,32 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn load() -> Result<Self, ParseConfigError> {
-        confy::load(APP_NAME, CONFIG_NAME).map_err(ParseConfigError::Loading)
+    pub fn load() -> eyre::Result<Self> {
+        confy::load(APP_NAME, CONFIG_NAME)
+            .map_err(ParseConfigError::Loading)
+            .wrap_err("error loading config")
     }
 
-    pub fn path() -> Result<String, ParseConfigError> {
+    pub fn path() -> eyre::Result<String> {
         let path = confy::get_configuration_file_path(APP_NAME, CONFIG_NAME)
             .map_err(ParseConfigError::Loading)?;
 
         Ok(path.display().to_string())
     }
 
-    pub fn view() -> Result<String, ParseConfigError> {
+    pub fn view() -> eyre::Result<String> {
         Ok(format!("{}", Self::load()?))
     }
 
-    pub fn get_location(&self) -> Result<String, ParseConfigError> {
+    pub fn get_location(&self) -> eyre::Result<String> {
         match &self.location {
             Some(location) => Ok(location.clone()),
-            None => Err(ParseConfigError::Missing("location".to_owned())),
+            None => Err(ParseConfigError::Missing("location".to_owned()))
+                .wrap_err("error getting location"),
         }
     }
 
-    pub fn set_location(location: &str) -> Result<String, ParseConfigError> {
+    pub fn set_location(location: &str) -> eyre::Result<String> {
         let mut config = Self::load()?;
 
         config.location = Some(location.to_owned());
@@ -56,7 +60,7 @@ impl Config {
         Ok("location stored successfully".to_string())
     }
 
-    pub fn set_unit(unit: Unit) -> Result<String, ParseConfigError> {
+    pub fn set_unit(unit: Unit) -> eyre::Result<String> {
         let mut config = Self::load()?;
 
         config.unit = unit;
@@ -65,18 +69,17 @@ impl Config {
         Ok(format!("unit stored as: {}", unit))
     }
 
-    pub fn get_weatherapi_token(&self) -> Result<String, ParseConfigError> {
+    pub fn get_weatherapi_token(&self) -> eyre::Result<String> {
         match &self.weatherapi_token {
             Some(token) => Ok(token.clone()),
             None => {
                 Err(ParseConfigError::Missing("weatherapi token".to_owned()))
+                    .wrap_err("error getting api token")
             }
         }
     }
 
-    pub fn set_weatherapi_token(
-        token: &str,
-    ) -> Result<String, ParseConfigError> {
+    pub fn set_weatherapi_token(token: &str) -> eyre::Result<String> {
         let mut config = Self::load()?;
 
         config.weatherapi_token = Some(token.to_owned());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
-use std::error::Error;
-
 use clap::Parser;
+use eyre::eyre;
 use serde::Serialize;
 
 use args::*;
@@ -13,7 +12,7 @@ pub mod icons;
 mod location;
 mod weather;
 
-pub fn run() -> Result<String, Box<dyn Error>> {
+pub fn run() -> eyre::Result<String> {
     let args = ConditionsArgs::parse();
 
     let result = match &args.command {
@@ -72,7 +71,7 @@ impl From<weather::Conditions> for Output {
     }
 }
 
-fn current_conditions() -> Result<String, Box<dyn Error>> {
+fn current_conditions() -> eyre::Result<String> {
     let config = Config::load()?;
 
     let location = match config.location {
@@ -94,7 +93,7 @@ fn current_conditions() -> Result<String, Box<dyn Error>> {
 
     let weatherapi_token = match config.weatherapi_token {
         Some(token) => token,
-        None => return Err("weatherapi token not set".into()),
+        None => return Err(eyre!("weatherapi token not set")),
     };
 
     let mut conditions = Conditions::current(&weatherapi_token, &location)?;

--- a/src/weather.rs
+++ b/src/weather.rs
@@ -74,10 +74,7 @@ impl From<WeatherAPIResult> for Conditions {
 }
 
 impl Conditions {
-    pub fn current(
-        key: &str,
-        location: &str,
-    ) -> Result<Self, FetchConditionsError> {
+    pub fn current(key: &str, location: &str) -> eyre::Result<Self> {
         let query = vec![("key", key), ("q", location)];
 
         let parsed = ureq::get(WEATHERAPI_URL)


### PR DESCRIPTION
An example error report:

```
❯ cargo run -q -- location view
error getting location
[2023-07-26T23:59:56Z ERROR conditions] error getting location

    Caused by:
        configuration for location not found

    Location:
        src/config.rs:50:18
```