### PR TITLE
feat: allow unset of config settings

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -46,10 +46,12 @@ pub struct WeatherApiKeyCommand {
 
 #[derive(Debug, Subcommand)]
 pub enum WeatherApiKeySubcommand {
-    /// Store your weatherapi.com api-key
+    /// Store your API key
     Set(SetApiKey),
-    /// View stored weatherapi.com api-key
+    /// Display the current key
     View,
+    /// Remove the stored key
+    Unset,
 }
 
 #[derive(Debug, Args)]
@@ -70,6 +72,8 @@ pub enum LocationSubcommand {
     Set(SetLocation),
     /// View stored location
     View,
+    /// Unset current location
+    Unset,
 }
 
 #[derive(Debug, Args)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -73,6 +73,15 @@ impl Config {
         Ok("location stored successfully".to_string())
     }
 
+    pub fn unset_location() -> eyre::Result<String> {
+        let mut config = Self::load()?;
+
+        config.location = None;
+        config.store()?;
+
+        Ok("location unset successfully".to_string())
+    }
+
     pub fn set_unit(unit: Unit) -> eyre::Result<String> {
         let mut config = Self::load()?;
 
@@ -84,21 +93,28 @@ impl Config {
 
     pub fn get_weatherapi_token(&self) -> eyre::Result<String> {
         match &self.weatherapi_token {
-            Some(token) => Ok(token.clone()),
-            None => {
-                Err(ParseConfigError::Missing("weatherapi token".to_owned()))
-                    .wrap_err("error getting api token")
-            }
+            Some(key) => Ok(key.clone()),
+            None => Err(ParseConfigError::Missing("weatherapi key".to_owned()))
+                .wrap_err("error getting api key"),
         }
     }
 
-    pub fn set_weatherapi_token(token: &str) -> eyre::Result<String> {
+    pub fn set_weatherapi_token(key: &str) -> eyre::Result<String> {
         let mut config = Self::load()?;
 
-        config.weatherapi_token = Some(token.to_owned());
+        config.weatherapi_token = Some(key.to_owned());
         config.store()?;
 
-        Ok("weatherapi.com token stored successfully".to_owned())
+        Ok("weatherapi.com key stored successfully".to_owned())
+    }
+
+    pub fn unset_weatherapi_token() -> eyre::Result<String> {
+        let mut config = Self::load()?;
+
+        config.weatherapi_token = None;
+        config.store()?;
+
+        Ok("weatherapi.com key unset successfully".to_owned())
     }
 
     pub fn store(&self) -> eyre::Result<()> {
@@ -113,7 +129,7 @@ impl fmt::Display for Config {
 
         write!(
             fmt,
-            "Stored Configuration\n  Coordinates: {}\n  Postal Code: {}\n  Unit: {}\n  Weather API Token: {}",
+            "Stored Configuration\n  Coordinates: {}\n  Postal Code: {}\n  Unit: {}\n  Weather API Key: {}",
             location.loc.clone(),
             location.postal_code.clone(),
             self.unit,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ pub fn run() -> eyre::Result<String> {
             LocationSubcommand::View => {
                 Config::load()?.get_location()?.to_string()
             }
+            LocationSubcommand::Unset => Config::unset_location()?,
         },
         Command::WeatherApiKey(cmd) => match &cmd.command {
             WeatherApiKeySubcommand::Set(input) => {
@@ -38,6 +39,7 @@ pub fn run() -> eyre::Result<String> {
 
                 format!("token stored as: {}", token)
             }
+            WeatherApiKeySubcommand::Unset => Config::unset_weatherapi_token()?,
         },
         Command::Unit(cmd) => match &cmd.command {
             UnitSubcommand::Set(unit) => Config::set_unit(unit.unit)?,


### PR DESCRIPTION
The following config settings can now be unset

- location
- weather-api-key

Resolves #62
