### PR TITLE
feat(weather): add failover

### DIFF
--- a/src/conditions.rs
+++ b/src/conditions.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 
-use crate::{config::Config, weather::CurrentConditions};
+use crate::{config::Config, weather::CurrentConditions, weather::Provider};
 
 #[derive(Debug, Serialize)]
 struct Output {
@@ -42,24 +42,28 @@ impl Conditions {
     /// - compose output structure
     /// - convert output to JSON and return
     pub fn fetch(&self) -> eyre::Result<String> {
-        let provider = match &self.config.weatherapi_token {
-            Some(token) => {
-                crate::weather::Provider::WeatherAPI(token.to_string())
-            }
-            None => crate::weather::Provider::OpenMeteo,
-        };
+        let mut providers = Vec::new();
+
+        if let Some(api_key) = &self.config.weatherapi_token {
+            providers.push(Provider::WeatherAPI(api_key.to_string()));
+        }
+
+        providers.push(Provider::OpenMeteo);
 
         let location = self.config.get_location()?;
 
-        let mut conditions = crate::weather::CurrentConditions::get(
-            provider.clone(),
+        let mut conditions = CurrentConditions::get(
+            providers,
             self.config.unit,
             &location.latitude,
             &location.longitude,
         )?;
 
-        conditions
-            .set_icon(conditions.time_of_day.icon(provider, conditions.code));
+        conditions.set_icon(
+            conditions
+                .time_of_day
+                .icon(conditions.provider.clone(), conditions.code),
+        );
 
         let output = Output::from(conditions);
 

--- a/src/weather/open_meteo.rs
+++ b/src/weather/open_meteo.rs
@@ -54,6 +54,8 @@ struct Response {
 
 impl WeatherProvider for Client {
     fn current(&self) -> eyre::Result<CurrentConditions> {
+        eprintln!("fetching weather from open-meteo.com");
+
         let parsed = ureq::get(URL)
             .query_pairs(self.query_pairs())
             .call()?
@@ -79,6 +81,7 @@ impl From<Response> for CurrentConditions {
             temp_f: result.current_weather.temperature,
             time_of_day: TimeOfDay::from(result.current_weather.is_day),
             icon: None,
+            provider: super::Provider::OpenMeteo,
         }
     }
 }

--- a/src/weather/weather_api.rs
+++ b/src/weather/weather_api.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 use super::{CurrentConditions, WeatherProvider};
 use crate::icons::TimeOfDay;
 
-static WEATHERAPI_URL: &str = "http://api.weatherapi.com/v1/current.json";
+static URL: &str = "http://api.weatherapi.com/v1/current.json";
 
 pub struct Client {
     key: String,
@@ -23,7 +23,9 @@ impl Client {
 
 impl WeatherProvider for Client {
     fn current(&self) -> eyre::Result<CurrentConditions> {
-        let parsed = ureq::get(WEATHERAPI_URL)
+        eprintln!("fetching weather from weatherapi.com");
+
+        let parsed = ureq::get(URL)
             .query_pairs(self.query_pairs())
             .call()?
             .into_json::<WeatherAPIResult>()?;
@@ -90,6 +92,7 @@ impl From<WeatherAPIResult> for CurrentConditions {
             temp_f: result.current.temp_f,
             time_of_day: TimeOfDay::from(result.current.is_day),
             icon: None,
+            provider: super::Provider::WeatherAPI("".to_string()),
         }
     }
 }


### PR DESCRIPTION
If the weatherapi.com api-key is present _and_ the request to that api fails, we will now failover to open-meteo.com api.

Resolves #76
