### PR TITLE
refactor: towards (more) simplicity

### DIFF
--- a/src/icons.rs
+++ b/src/icons.rs
@@ -25,7 +25,7 @@ impl TimeOfDay {
         code: i32,
     ) -> String {
         let icons: &HashMap<i32, &'static str> = match provider {
-            Provider::WeatherAPI(_) => match self {
+            Provider::WeatherAPI => match self {
                 TimeOfDay::Day => &WEATHERAPI_DAY_ICONS,
                 TimeOfDay::Night => &WEATHERAPI_NIGHT_ICONS,
             },
@@ -219,24 +219,23 @@ lazy_static! {
 
 #[test]
 fn valid_code_for_day() {
-    let icon = TimeOfDay::Day
-        .icon(crate::weather::Provider::WeatherAPI("".to_string()), 1006);
+    let icon = TimeOfDay::Day.icon(crate::weather::Provider::WeatherAPI, 1006);
 
     assert_eq!(icon, " ".to_string());
 }
 
 #[test]
 fn valid_code_for_night() {
-    let icon = TimeOfDay::Night
-        .icon(crate::weather::Provider::WeatherAPI("".to_string()), 1195);
+    let icon =
+        TimeOfDay::Night.icon(crate::weather::Provider::WeatherAPI, 1195);
 
     assert_eq!(icon, "".to_string());
 }
 
 #[test]
 fn invalid_code_for() {
-    let icon = TimeOfDay::Night
-        .icon(crate::weather::Provider::WeatherAPI("".to_string()), 9999);
+    let icon =
+        TimeOfDay::Night.icon(crate::weather::Provider::WeatherAPI, 9999);
 
     assert_eq!(icon, "?".to_string());
 }

--- a/src/location/from_ip.rs
+++ b/src/location/from_ip.rs
@@ -43,5 +43,7 @@ impl Client {
 }
 
 impl crate::api::Fetchable<Response, Location> for Client {
-    const URL: &'static str = "https://ipinfo.io/json";
+    fn url(&self) -> &'static str {
+        "https://ipinfo.io/json"
+    }
 }

--- a/src/location/from_postal_code.rs
+++ b/src/location/from_postal_code.rs
@@ -80,10 +80,12 @@ impl Client {
 }
 
 impl crate::api::Fetchable<Response, Location> for Client {
-    const URL: &'static str = "https://nominatim.openstreetmap.org/search.php";
+    fn url(&self) -> &'static str {
+        "https://nominatim.openstreetmap.org/search.php"
+    }
 
     fn fetch(&self) -> eyre::Result<Location> {
-        ureq::get(Self::URL)
+        ureq::get(self.url())
             .query_pairs(self.query_pairs())
             .call()
             .map_err(|_| eyre::eyre!("unknown error"))

--- a/src/location/mod.rs
+++ b/src/location/mod.rs
@@ -1,6 +1,5 @@
 use std::fmt;
 
-use eyre::WrapErr;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -14,26 +13,6 @@ pub enum ParseCoordinatesError {
     InvalidFormat(String),
     #[error("provided postal code was not found")]
     UnknownLocation(String),
-}
-
-pub trait HttpClient<T, U>
-where
-    for<'de> T: Deserialize<'de>,
-    U: From<T>,
-{
-    fn fetch(&self) -> eyre::Result<U> {
-        ureq::get(self.url())
-            .query_pairs(self.query_pairs())
-            .call()
-            .map_err(|_| eyre::eyre!("unknown error"))?
-            .into_json::<T>()
-            .wrap_err(format!("error parsing response from: {}", self.url()))
-            .map(U::from)
-    }
-
-    fn url(&self) -> &str;
-
-    fn query_pairs(&self) -> Vec<(&str, &str)>;
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]

--- a/src/weather/open_meteo.rs
+++ b/src/weather/open_meteo.rs
@@ -2,6 +2,8 @@ use serde::Deserialize;
 
 use super::{CurrentConditions, Provider};
 use crate::icons::TimeOfDay;
+use crate::location::Location;
+use crate::Config;
 
 // {
 //   "latitude": 35.159126,
@@ -26,13 +28,15 @@ pub struct Client {
 }
 
 impl Client {
-    pub fn new(unit: crate::Unit, latitude: String, longitude: String) -> Self {
+    pub fn new(config: &Config, location: &Location) -> Self {
+        let unit = config.unit.to_string();
+
         Self {
             query: vec![
                 ("current_weather".to_string(), "true".to_string()),
-                ("temperature_unit".to_string(), unit.to_string()),
-                ("latitude".to_string(), latitude),
-                ("longitude".to_string(), longitude),
+                ("temperature_unit".to_string(), unit),
+                ("latitude".to_string(), location.latitude.clone()),
+                ("longitude".to_string(), location.longitude.clone()),
             ],
         }
     }
@@ -51,7 +55,9 @@ pub struct Response {
 }
 
 impl crate::api::Fetchable<Response, CurrentConditions> for Client {
-    const URL: &'static str = "https://api.open-meteo.com/v1/forecast";
+    fn url(&self) -> &'static str {
+        "https://api.open-meteo.com/v1/forecast"
+    }
 
     fn query(&self) -> Option<&Vec<(String, String)>> {
         Some(&self.query)


### PR DESCRIPTION
### Validity

Introduce `is_valid` for `Fetchable`. This allows each implementation to determine internally whether or not it in a proper state to make a request. Previously some of this logic (eg. do we have an api-key) had bled out of the implementation.

### Context

Push `config` and `location` down to weather providers. Previously the caller of these providers had to differentiate what their needs were (api-key? unit of measure?).

### Trait Object

It's unconventional to have a `const` defined in a trait, move `URL` to - `fn url()`.

### Dead Code

Remove `location::HttpClient`, it was effectively replaced by `api::Fetchable`.