### PR TITLE
ci: prevent release-plz running when dependabot

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -13,6 +13,7 @@ jobs:
   release-plz:
     name: Release-plz
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       # Generating a GitHub token, so that PRs and tags created by
       # the release-plz-action can trigger actions workflows.


### PR DESCRIPTION
The dependabot[bot] has not given permissions to the custom GitHub app that was created to provide tokens to this workflow (via `tibdex/github-app-token@v2`).

Resolves #103
