### PR TITLE
feat(current): allow optional region

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -14,8 +14,8 @@ pub struct Conditions {
 pub enum Command {
     /// View configuration information
     Config(ConfigCommand),
-    /// Get the current weather conditions
-    Current,
+    /// Get the current weather conditions (optional provide location)
+    Current { region: Option<String> },
     /// Location conditions apply to
     Location(LocationCommand),
     /// weatherapi.com api-key

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,10 +41,10 @@ pub async fn run() -> eyre::Result<String> {
             ConfigSubcommand::Path => Config::location()?,
             ConfigSubcommand::View => Config::view()?,
         },
-        Command::Current => {
+        Command::Current { region } => {
             let (config, mut cache) = init().await?;
 
-            conditions::Conditions::new(config)
+            conditions::Conditions::new(config, region.clone())
                 .fetch(&mut cache)
                 .await?
         }

--- a/src/weather/mod.rs
+++ b/src/weather/mod.rs
@@ -52,9 +52,7 @@ impl CurrentConditions {
 
             match result {
                 Ok(conditions) => return Ok(conditions),
-                Err(_) => {
-                    eprintln!("error fetching weather from: {source}");
-                }
+                Err(err) => eprintln!("{err}: {source}"),
             }
         }
 


### PR DESCRIPTION
This will allow the user to check the current conditions in a region other than (inferred) current or configured location.

Resolves #122
