### PR TITLE
chore: remove usage of `eprintln!`

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -72,11 +72,6 @@ impl Config {
             None => {
                 let inferred = location::get(cache, None).await?;
 
-                eprintln!(
-                    "location not set, inferred postal code: {}",
-                    inferred.postal_code
-                );
-
                 Ok(inferred)
             }
         }

--- a/src/location/mod.rs
+++ b/src/location/mod.rs
@@ -67,18 +67,13 @@ pub async fn get(
         return Ok(location);
     };
 
-    if let Some(location) = cache.get(region).await? {
-        eprintln!(
-            "location read from cache, postal code: {}",
-            location.postal_code
-        );
-
-        Ok(location)
-    } else {
+    let Some(location) = cache.get(region).await? else {
         let location = from_postal_code::Client::new(region)?.fetch()?;
 
         cache.set(&location).await?;
 
-        Ok(location)
-    }
+        return Ok(location);
+    };
+
+    Ok(location)
 }

--- a/src/weather/mod.rs
+++ b/src/weather/mod.rs
@@ -50,9 +50,8 @@ impl CurrentConditions {
                 }
             };
 
-            match result {
-                Ok(conditions) => return Ok(conditions),
-                Err(err) => eprintln!("{err}: {source}"),
+            if result.is_ok() {
+                return result;
             }
         }
 


### PR DESCRIPTION
These messages were useful in development but likely will only cause confusion to users. Reconsider using `env_logger` in the future for dev logging.

Resolves #124
